### PR TITLE
Unset background of inline code so it renders properly in headers

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1,6 +1,6 @@
 /*───────────────────────────────────────────────────────
 Royal Velvet
-Version 0.9.3
+Version 0.9.4
 Created by @caro401
 Readme:
 https://github.com/caro401/royal-velvet
@@ -331,6 +331,10 @@ code,
 .cm-s-obsidian .HyperMD-codeblock-begin,
 .cm-s-obsidian .HyperMD-codeblock-end {
   color: var(--cyan);
+}
+
+.markdown-rendered code {
+  background-color: unset;
 }
 
 /*--Links--*/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "royal-velvet",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "A theme for obsidian.md, inspired by the beautiful colours of Royal Velvet Obsidian and the distinct colours used in programming syntax highlighting themes.",
   "main": "",
   "scripts": {


### PR DESCRIPTION
closes #7 

This means inline code in reading mode doesn't have the darker background in other places, but I actually like that better