### PR TITLE
Remove gradient from active note title, so emoji display correctly

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1,6 +1,6 @@
 /*───────────────────────────────────────────────────────
 Royal Velvet
-Version 0.9.6
+Version 0.9.7
 Created by @caro401
 Readme:
 https://github.com/caro401/royal-velvet
@@ -178,7 +178,7 @@ SOFTWARE.
 }
 
 .view-header-title {
-  color: var(--pink-500);
+  color: var(--pinkSecondary);
 }
 
 .workspace-split.mod-root
@@ -190,14 +190,7 @@ SOFTWARE.
 /*Active Note Titlebar*/
 /*Note Title Bar: Text*/
 .workspace-leaf.mod-active .view-header-title {
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  -webkit-background-clip: text;
-  background-image: linear-gradient(
-    var(--gradientDegree),
-    var(--pink) 0,
-    var(--orange) 100%
-  );
+  color: var(--pink);
 }
 
 /*--Emphasis--*/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "royal-velvet",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "A theme for obsidian.md, inspired by the beautiful colours of Royal Velvet Obsidian and the distinct colours used in programming syntax highlighting themes.",
   "main": "",
   "scripts": {


### PR DESCRIPTION
Also fix bug in inactive note title colour. Helps with #11, but doesn't address headings in note body - this will need a plugin