### PR TITLE
Fix: use "Fira Code" as monospace font

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -43,6 +43,10 @@ SOFTWARE.
   --gradientDegree: 135deg;
 }
 
+body {
+  --font-monospace-theme: "Fira Code", "Source Code Pro", monospace; /*Code block text*/
+}
+
 /*Dark Theme Variables*/
 .theme-dark {
   --pink: #ff80bf;


### PR DESCRIPTION
In [Obsidian Release v0.14.4](https://forum.obsidian.md/t/obsidian-release-v0-14-4-insider-build/35026) CSS variables related to fonts have been changed, thus the default monospace font was used for code blocks etc. instead of Fira Code.