### PR TITLE
Fix characters disapperaing in headings #17

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -613,7 +613,7 @@ ol ol ol ol ol ol li::marker,
 /*
 [BUG] Characters disappearing in headings #17
 why? - this occurs in legacy editor with spell check enabled, if words in headings are marked by spell checker
-what causes this? - .CodeMirror.cm-spell-error setting red squiggly line as background-image, thus overwriting the color gradient
+what causes this? - .CodeMirror.cm-spell-error setting red a squiggly line as background-image, thus overwriting the color gradient and making the letters disappear
 */
 
 .CodeMirror .cm-spell-error {
@@ -622,42 +622,42 @@ what causes this? - .CodeMirror.cm-spell-error setting red squiggly line as back
   text-decoration-color: red;
 }
 
-.cm-header.cm-header-1.cm-overlay.cm-spell-error {
+.cm-header-1.cm-spell-error {
   background-image: linear-gradient(
     var(--gradientDegree),
     var(--pink) 0,
     var(--orange) 100%
   );
 }
-.cm-header.cm-header-2.cm-overlay.cm-spell-error {
+.cm-header-2.cm-spell-error {
   background-image: linear-gradient(
     var(--gradientDegree),
     var(--orange) 0,
     var(--yellow) 100%
   );
 }
-.cm-header.cm-header-3.cm-overlay.cm-spell-error {
+.cm-header-3.cm-spell-error {
   background-image: linear-gradient(
     var(--gradientDegree),
     var(--yellow) 0,
     var(--green) 100%
   );
 }
-.cm-header.cm-header-4.cm-overlay.cm-spell-error {
+.cm-header-4.cm-spell-error {
   background-image: linear-gradient(
     var(--gradientDegree),
     var(--green) 0,
     var(--cyan) 100%
   );
 }
-.cm-header.cm-header-5.cm-overlay.cm-spell-error {
+.cm-header-5.cm-spell-error {
   background-image: linear-gradient(
     var(--gradientDegree),
     var(--cyan) 0,
     var(--purple) 100%
   );
 }
-.cm-header.cm-header-6.cm-overlay.cm-spell-error {
+.cm-header-6.cm-spell-error {
   background-image: linear-gradient(
     var(--gradientDegree),
     var(--purple) 0,

--- a/obsidian.css
+++ b/obsidian.css
@@ -611,15 +611,10 @@ ol ol ol ol ol ol li::marker,
 }
 
 /*
-
 [BUG] Characters disappearing in headings #17
-
 why? - this occurs in legacy editor with spell check enabled, if words in headings are marked by spell checker
-
-what causes this? - this is caused by .CodeMirror .cm-spell-error setting a new background-image
-
+what causes this? - .CodeMirror.cm-spell-error setting red squiggly line as background-image, thus overwriting the color gradient
 */
-
 
 .CodeMirror .cm-spell-error {
   background-image: unset;
@@ -632,5 +627,40 @@ what causes this? - this is caused by .CodeMirror .cm-spell-error setting a new 
     var(--gradientDegree),
     var(--pink) 0,
     var(--orange) 100%
+  );
+}
+.cm-header.cm-header-2.cm-overlay.cm-spell-error {
+  background-image: linear-gradient(
+    var(--gradientDegree),
+    var(--orange) 0,
+    var(--yellow) 100%
+  );
+}
+.cm-header.cm-header-3.cm-overlay.cm-spell-error {
+  background-image: linear-gradient(
+    var(--gradientDegree),
+    var(--yellow) 0,
+    var(--green) 100%
+  );
+}
+.cm-header.cm-header-4.cm-overlay.cm-spell-error {
+  background-image: linear-gradient(
+    var(--gradientDegree),
+    var(--green) 0,
+    var(--cyan) 100%
+  );
+}
+.cm-header.cm-header-5.cm-overlay.cm-spell-error {
+  background-image: linear-gradient(
+    var(--gradientDegree),
+    var(--cyan) 0,
+    var(--purple) 100%
+  );
+}
+.cm-header.cm-header-6.cm-overlay.cm-spell-error {
+  background-image: linear-gradient(
+    var(--gradientDegree),
+    var(--purple) 0,
+    var(--pink) 100%
   );
 }

--- a/obsidian.css
+++ b/obsidian.css
@@ -609,3 +609,28 @@ ol ol ol ol ol ol li::marker,
 .HyperMD-list-line.HyperMD-list-line-6 .cm-formatting-list {
   color: var(--purple);
 }
+
+/*
+
+[BUG] Characters disappearing in headings #17
+
+why? - this occurs in legacy editor with spell check enabled, if words in headings are marked by spell checker
+
+what causes this? - this is caused by .CodeMirror .cm-spell-error setting a new background-image
+
+*/
+
+
+.CodeMirror .cm-spell-error {
+  background-image: unset;
+  text-decoration: underline;
+  text-decoration-color: red;
+}
+
+.cm-header.cm-header-1.cm-overlay.cm-spell-error {
+  background-image: linear-gradient(
+    var(--gradientDegree),
+    var(--pink) 0,
+    var(--orange) 100%
+  );
+}


### PR DESCRIPTION
#17 seems to be caused by having spell check enabled and using legacy editor mode. the spell checker is overwriting the background-image attribute, which is used to achieve the color gradient effect in headings.

I also changed the red squiggly line to a red underline (legacy editor only)

![Screenshot 2022-07-11 164249](https://user-images.githubusercontent.com/78652025/178290861-cd4635d5-d198-46c6-954b-1657c0424bff.png)

also thanks a lot @Toiler-zz for the great bug report! 😀


