### PR TITLE
removed unsetting backgound of inline code

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -330,10 +330,6 @@ code,
   color: var(--cyan);
 }
 
-.markdown-rendered code {
-  background-color: unset;
-}
-
 /*--inline code in headings--*/
 .markdown-preview-view h1 code,
 .markdown-preview-view h2 code,


### PR DESCRIPTION
inline code snippets have no background in reading mode

before: 
![2022-08-31 20_22_35-Markdown Syntax - obsidian-theme-dev-vault-main - Obsidian v0 15 9](https://user-images.githubusercontent.com/78652025/187757439-1242236f-6b44-4a3e-924d-91494d6391b7.png)

after:
![2022-08-31 20_21_36-Markdown Syntax - obsidian-theme-dev-vault-main - Obsidian v0 15 9](https://user-images.githubusercontent.com/78652025/187757452-d3574cb6-4c78-4ecd-9514-1711a061b69e.png)
