### PR TITLE
colored urls in editing mode

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -367,11 +367,16 @@ a.internal-link.is-unresolved {
 
 a.external-link,
 .cm-s-obsidian span.cm-link,
-.cm-s-obsidian span.cm-link.cm-quote {
+.cm-s-obsidian span.cm-link.cm-quote,
+.cm-s-obsidian span.cm-url {
   color: var(--green);
 }
+.cm-s-obsidian span.cm-url {
+  text-decoration: unset;
+}
 .external-link:hover,
-.cm-s-obsidian span.cm-link:hover {
+.cm-s-obsidian span.cm-link:hover,
+.cm-s-obsidian span.cm-url:hover {
   color: var(--greenSecondary);
 }
 


### PR DESCRIPTION
links are grey in editing mode, so I made them green

Before:
![2022-08-31 20_29_17-Links - obsidian-theme-dev-vault-main - Obsidian v0 15 9](https://user-images.githubusercontent.com/78652025/187759105-b993c284-4d09-4490-9554-02b1755857d5.png)

After: 
![2022-08-31 20_28_57-Links - obsidian-theme-dev-vault-main - Obsidian v0 15 9](https://user-images.githubusercontent.com/78652025/187759098-14df43a8-bf26-4f65-80a1-a656b7b0d18e.png)
