### PR TITLE
colored search result highlights

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -609,3 +609,8 @@ ol ol ol ol ol ol li::marker,
 .HyperMD-list-line.HyperMD-list-line-6 .cm-formatting-list {
   color: var(--purple);
 }
+
+.suggestion-highlight,
+.search-result-file-matched-text {
+  color: var(--pink);
+}


### PR DESCRIPTION
I colored the highlighted letters in the search box. imo this improves the visibility by a lot. 
also please let me know whether I should create separate pr for each small change or if I should combine them into one pr.

Before:
![2022-08-31 20_17_47-Markdown Syntax - obsidian-theme-dev-vault-main - Obsidian v0 15 9](https://user-images.githubusercontent.com/78652025/187760071-39ee7e23-8011-4c42-9d90-84faa9c6be81.png)

After:
![2022-08-31 20_17_31-Markdown Syntax - obsidian-theme-dev-vault-main - Obsidian v0 15 9](https://user-images.githubusercontent.com/78652025/187760092-4b41d590-c178-4ba1-92a1-25697b6c88e6.png)
