### PR TITLE
Configurable color for document title

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The inline document title's color can be set as any of the following;
 
 - **Disabled** - uses normal text color
 - **Custom color** - based on the hue of your configured accent color
-- **Match with the heading level color pattern** - adjusts all heading colors slightly
 - **Rainbow**
 - **Same as a specific heading level**
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ If you use emoji in headings, you will need to add a plugin to make these displa
 }
 ```
 
+## Customization
+
+Customization options are made available by [The Style Settings Plugin](https://github.com/mgmeyers/obsidian-style-settings).
+
+### Inline Document Title Color
+
+The inline document title's color can be set as any of the following;
+
+- **Disabled** - uses normal text color
+- **Custom color** - based on the hue of your configured accent color
+- **Match with the heading level color pattern** - adjusts all heading colors slightly
+- **Rainbow**
+- **Same as a specific heading level**
+
+By default, it is set to the same color as the level 1 heading.
+
 ## Feedback
 
 If you have any issues or suggestions, please [submit an issue](https://github.com/caro401/royal-velvet/issues/new) or raise a [pull request](https://github.com/caro401/royal-velvet/pulls/).

--- a/theme.css
+++ b/theme.css
@@ -44,9 +44,6 @@ settings:
         label: Accent Color (hue)
         value: doc-title-accent
       -
-        label: match headings
-        value: doc-title-match
-      -
         label: Rainbow
         value: doc-title-rainbow
       -
@@ -122,16 +119,6 @@ body {
   --cyan-600: rgba(128, 255, 234, 0.6);
 
   --purple-pink: #ca80df;
-
-  --core-saturation: 100%;
-  --core-lightness: 75.1%;
-  --seven-split-pink: hsl(330.20, var(--core-saturation), var(--core-lightness));
-  --seven-split-orange: hsl(21.63, var(--core-saturation), var(--core-lightness));
-  --seven-split-yellow: hsl(73.06, var(--core-saturation), var(--core-lightness));
-  --seven-split-green: hsl(124.49, var(--core-saturation), var(--core-lightness));
-  --seven-split-cyan: hsl(175.91, var(--core-saturation), var(--core-lightness));
-  --seven-split-purple: hsl(227.34, var(--core-saturation), var(--core-lightness));
-  --seven-split-seventh: hsl(278.77, var(--core-saturation), var(--core-lightness));
 
   --background-modifier-cover: var(--blackXDark); /*Obsidian Title Bar Bg*/
   --background-primary: var(--black); /*Note background*/
@@ -325,35 +312,8 @@ body:not(.doc-title-disable) .inline-title {
 body.doc-title-accent .inline-title {
   background-image: linear-gradient(
     var(--gradientDegree),
-    hsl(calc(var(--accent-h) + 30), var(--core-saturation), var(--core-lightness)) 0,
-    hsl(calc(var(--accent-h) - 30), var(--core-saturation), var(--core-lightness)) 100%
-  );
-}
-
-body.doc-title-match {
-  --pink: var(--seven-split-pink);
-  --orange: var(--seven-split-orange);
-  --yellow: var(--seven-split-yellow);
-  --green: var(--seven-split-green);
-  --cyan: var(--seven-split-cyan);
-  --purple: var(--seven-split-purple);
-  --seventh: var(--seven-split-seventh);
-}
-
-body.doc-title-match .inline-title {
-  background-image: linear-gradient(
-    var(--gradientDegree),
-    var(--seventh) 0,
-    var(--pink) 100%
-  );
-}
-
-body.doc-title-match h6,
-body.doc-title-match .cm-header-6 {
-  background-image: linear-gradient(
-    var(--gradientDegree),
-    var(--purple) 0,
-    var(--seventh) 100%
+    hsl(calc(var(--accent-h) + 30), 100%, 75.1%) 0,
+    hsl(calc(var(--accent-h) - 30), 100%, 75.1%) 100%
   );
 }
 

--- a/theme.css
+++ b/theme.css
@@ -24,6 +24,51 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ────────────────────────────────────────────────────── */
 
+/* @settings
+
+name: Royal Velvet
+id: royal-velvet
+settings:
+  -
+    id: inline-document-title-color
+    title: Inline Document Title Color
+    description: Change the color of the inline document title to match another heading or a custom hue.
+    type: class-select
+    allowEmpty: false
+    default: doc-title-h1
+    options:
+      -
+        label: Disabled
+        value: doc-title-disable
+      -
+        label: Accent Color (hue)
+        value: doc-title-accent
+      -
+        label: match headings
+        value: doc-title-match
+      -
+        label: Rainbow
+        value: doc-title-rainbow
+      -
+        label: Heading 1
+        value: doc-title-h1
+      -
+        label: Heading 2
+        value: doc-title-h2
+      -
+        label: Heading 3
+        value: doc-title-h3
+      -
+        label: Heading 4
+        value: doc-title-h4
+      -
+        label: Heading 5
+        value: doc-title-h5
+      -
+        label: Heading 6
+        value: doc-title-h6
+*/
+
 /*Fonts*/
 
 @import url("https://fonts.googleapis.com/css2?family=Fira+Code&family=Fira+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap");
@@ -261,8 +306,70 @@ del {
 }
 
 /*--Headers/Headings--*/
+body:not(.doc-title-disable) .inline-title {
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  -webkit-background-clip: text;
+}
+
+body.doc-title-accent .inline-title {
+  background-image: linear-gradient(
+    var(--gradientDegree),
+    hsl(calc(var(--accent-h) + 30), 100%, 75.1%) 0,
+    hsl(calc(var(--accent-h) - 30), 100%, 75.1%) 100%
+  );
+}
+
+body.doc-title-match {
+  --pink: hsl(330.20, 100%, 75.1%);
+  --orange: hsl(21.63, 100%, 75.1%);
+  --yellow: hsl(73.06, 100%, 75.1%);
+  --green: hsl(124.49, 100%, 75.1%);
+  --cyan: hsl(175.91, 100%, 75.1%);
+  --purple: hsl(227.34, 100%, 75.1%);
+  --seventh: hsl(278.77, 100%, 75.1%);
+}
+
+body.doc-title-match .inline-title {
+  background-image: linear-gradient(
+    var(--gradientDegree),
+    var(--seventh) 0,
+    var(--pink) 100%
+  );
+}
+
+body.doc-title-match h6,
+body.doc-title-match .cm-header-6 {
+  background-image: linear-gradient(
+    var(--gradientDegree),
+    var(--purple) 0,
+    var(--seventh) 100%
+  );
+}
+
+body.doc-title-rainbow .inline-title {
+  background-image: linear-gradient(
+    var(--gradientDegree),
+    var(--pink) 0,
+    var(--orange) 8.33%,
+    var(--yellow) 16.66%,
+    var(--green) 25%,
+    var(--cyan) 33.33%,
+    var(--purple) 41.66%,
+    var(--pink) 50%,
+    var(--orange) 58.33%,
+    var(--yellow) 66.66%,
+    var(--green) 75%,
+    var(--cyan) 83.33%,
+    var(--purple) 91.66%,
+    var(--pink) 100%
+  );
+}
+
 h1,
-.cm-header-1, .inline-title {
+.cm-header-1,
+body.doc-title-h1 .inline-title,
+body:not([class*="doc-title"]) .inline-title {
   -webkit-text-fill-color: transparent;
   background-clip: text;
   -webkit-background-clip: text;
@@ -272,8 +379,10 @@ h1,
     var(--orange) 100%
   );
 } /*Source Mode*/
+
 h2,
-.cm-header-2 {
+.cm-header-2,
+body.doc-title-h2 .inline-title {
   -webkit-text-fill-color: transparent;
   background-clip: text;
   -webkit-background-clip: text;
@@ -283,8 +392,10 @@ h2,
     var(--yellow) 100%
   );
 } /*Source Mode*/
+
 h3,
-.cm-header-3 {
+.cm-header-3,
+body.doc-title-h3 .inline-title {
   -webkit-text-fill-color: transparent;
   background-clip: text;
   -webkit-background-clip: text;
@@ -294,8 +405,10 @@ h3,
     var(--green) 100%
   );
 } /*Source Mode*/
+
 h4,
-.cm-header-4 {
+.cm-header-4,
+body.doc-title-h4 .inline-title {
   -webkit-text-fill-color: transparent;
   background-clip: text;
   -webkit-background-clip: text;
@@ -305,8 +418,10 @@ h4,
     var(--cyan) 100%
   );
 } /*Source Mode*/
+
 h5,
-.cm-header-5 {
+.cm-header-5,
+body.doc-title-h5 .inline-title {
   -webkit-text-fill-color: transparent;
   background-clip: text;
   -webkit-background-clip: text;
@@ -316,8 +431,10 @@ h5,
     var(--purple) 100%
   );
 } /*Source Mode*/
+
 h6,
-.cm-header-6 {
+.cm-header-6,
+body.doc-title-h6 .inline-title {
   -webkit-text-fill-color: transparent;
   background-clip: text;
   -webkit-background-clip: text;
@@ -396,7 +513,7 @@ span.cm-inline-code.cm-strikethrough,
 .cm-hmd-internal-link .cm-underline,
 a.internal-link {
   /* color: var(--link-color); */
-  -webkit-text-fill-color: var(--link-color); 
+  -webkit-text-fill-color: var(--link-color);
 }
 
 :is(.cm-s-obsidian span.cm-hmd-internal-link,
@@ -431,7 +548,7 @@ a.internal-link.is-unresolved):hover {
   text-decoration-color: var(--link-unresolved-hover);
   color: var(--link-unresolved-hover);
   -webkit-text-fill-color: var(--link-unresolved-hover);
-  
+
 }
 
 a.external-link,

--- a/theme.css
+++ b/theme.css
@@ -123,6 +123,16 @@ body {
 
   --purple-pink: #ca80df;
 
+  --core-saturation: 100%;
+  --core-lightness: 75.1%;
+  --seven-split-pink: hsl(330.20, var(--core-lightness), var(--core-saturation));
+  --seven-split-orange: hsl(21.63, var(--core-lightness), var(--core-saturation));
+  --seven-split-yellow: hsl(73.06, var(--core-lightness), var(--core-saturation));
+  --seven-split-green: hsl(124.49, var(--core-lightness), var(--core-saturation));
+  --seven-split-cyan: hsl(175.91, var(--core-lightness), var(--core-saturation));
+  --seven-split-purple: hsl(227.34, var(--core-lightness), var(--core-saturation));
+  --seven-split-seventh: hsl(278.77, var(--core-lightness), var(--core-saturation));
+
   --background-modifier-cover: var(--blackXDark); /*Obsidian Title Bar Bg*/
   --background-primary: var(--black); /*Note background*/
   --background-primary-alt: var(--blackDark); /*Note Title background active*/
@@ -315,19 +325,19 @@ body:not(.doc-title-disable) .inline-title {
 body.doc-title-accent .inline-title {
   background-image: linear-gradient(
     var(--gradientDegree),
-    hsl(calc(var(--accent-h) + 30), 100%, 75.1%) 0,
-    hsl(calc(var(--accent-h) - 30), 100%, 75.1%) 100%
+    hsl(calc(var(--accent-h) + 30), var(--core-lightness), var(--core-saturation)) 0,
+    hsl(calc(var(--accent-h) - 30), var(--core-lightness), var(--core-saturation)) 100%
   );
 }
 
 body.doc-title-match {
-  --pink: hsl(330.20, 100%, 75.1%);
-  --orange: hsl(21.63, 100%, 75.1%);
-  --yellow: hsl(73.06, 100%, 75.1%);
-  --green: hsl(124.49, 100%, 75.1%);
-  --cyan: hsl(175.91, 100%, 75.1%);
-  --purple: hsl(227.34, 100%, 75.1%);
-  --seventh: hsl(278.77, 100%, 75.1%);
+  --pink: var(--seven-split-pink);
+  --orange: var(--seven-split-orange);
+  --yellow: var(--seven-split-yellow);
+  --green: var(--seven-split-green);
+  --cyan: var(--seven-split-cyan);
+  --purple: var(--seven-split-purple);
+  --seventh: var(--seven-split-seventh);
 }
 
 body.doc-title-match .inline-title {

--- a/theme.css
+++ b/theme.css
@@ -125,13 +125,13 @@ body {
 
   --core-saturation: 100%;
   --core-lightness: 75.1%;
-  --seven-split-pink: hsl(330.20, var(--core-lightness), var(--core-saturation));
-  --seven-split-orange: hsl(21.63, var(--core-lightness), var(--core-saturation));
-  --seven-split-yellow: hsl(73.06, var(--core-lightness), var(--core-saturation));
-  --seven-split-green: hsl(124.49, var(--core-lightness), var(--core-saturation));
-  --seven-split-cyan: hsl(175.91, var(--core-lightness), var(--core-saturation));
-  --seven-split-purple: hsl(227.34, var(--core-lightness), var(--core-saturation));
-  --seven-split-seventh: hsl(278.77, var(--core-lightness), var(--core-saturation));
+  --seven-split-pink: hsl(330.20, var(--core-saturation), var(--core-lightness));
+  --seven-split-orange: hsl(21.63, var(--core-saturation), var(--core-lightness));
+  --seven-split-yellow: hsl(73.06, var(--core-saturation), var(--core-lightness));
+  --seven-split-green: hsl(124.49, var(--core-saturation), var(--core-lightness));
+  --seven-split-cyan: hsl(175.91, var(--core-saturation), var(--core-lightness));
+  --seven-split-purple: hsl(227.34, var(--core-saturation), var(--core-lightness));
+  --seven-split-seventh: hsl(278.77, var(--core-saturation), var(--core-lightness));
 
   --background-modifier-cover: var(--blackXDark); /*Obsidian Title Bar Bg*/
   --background-primary: var(--black); /*Note background*/
@@ -325,8 +325,8 @@ body:not(.doc-title-disable) .inline-title {
 body.doc-title-accent .inline-title {
   background-image: linear-gradient(
     var(--gradientDegree),
-    hsl(calc(var(--accent-h) + 30), var(--core-lightness), var(--core-saturation)) 0,
-    hsl(calc(var(--accent-h) - 30), var(--core-lightness), var(--core-saturation)) 100%
+    hsl(calc(var(--accent-h) + 30), var(--core-saturation), var(--core-lightness)) 0,
+    hsl(calc(var(--accent-h) - 30), var(--core-saturation), var(--core-lightness)) 100%
   );
 }
 


### PR DESCRIPTION
Implements #26 

Added settings comment for style settings plugin
Added the following options for document title's color;
- same as h1 (default)
- same as h2
- same as h3
- same as h4
- same as h5
- same as h6
- match all headings (adjusts colors at `body` and adds a 7th color)
- rainbow
- custom (uses the hue of the configured accent color)
- disabled (no color or masking)
Added section to `README.md` detailing the settings

Regarding the rainbow gradient: the reason is cycles the colors twice is because in fullscreen single document mode, the title looks almost identical to a heading when only cycling once. Cycling twice squishes the colors close enough to be visually distinct from the existing headings.

The default setting will apply both when style settings is installed and active, and when it is not installed, the default setting is to be identical to the h1, the same as before this PR.

### Screenshots

Disabled:

![disabled](https://user-images.githubusercontent.com/85991558/214921533-10ff20d3-3b94-48fe-834f-e91ab33cd74d.png)

Accent color (with default accent color):

![accent color](https://user-images.githubusercontent.com/85991558/214921638-91a907c0-8924-4844-965d-e6b012729714.png)

Match headings:

![match headings](https://user-images.githubusercontent.com/85991558/214921805-70454a8d-eb97-48aa-ae5d-0cd4feaddd32.png)

Rainbow:

![rainbow](https://user-images.githubusercontent.com/85991558/214921944-c3a420ba-9ffb-4f00-9d5c-72cb3fe6a855.png)

Heading 1 / default:

![heading 1 / default](https://user-images.githubusercontent.com/85991558/214922058-8e648e67-4f7e-41d6-910c-b30653eb2ad7.png)

Let me know if there are any changes you would like me to make.
