### PR TITLE
Properties keys inputs shouldn't have a different background colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.1
+
+- Quick fix for property key styling bug (#37) 
+
 ## 0.11.0
 
 - added light theme (#30), thanks to [WillsterJohnson](https://github.com/WillsterJohnson)

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {  
    "name": "Royal Velvet",
-   "version": "0.11.0",
+   "version": "0.11.1",
    "minAppVersion": "1.0.0",
    "author": "@caro401",
    "authorUrl": "https://github.com/caro401"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "royal-velvet",
-  "version": "0.9.7",
+  "version": "0.11.1",
   "description": "A theme for obsidian.md, inspired by the beautiful colours of Royal Velvet Obsidian and the distinct colours used in programming syntax highlighting themes.",
   "main": "",
   "scripts": {

--- a/theme.css
+++ b/theme.css
@@ -812,7 +812,7 @@ section.footnotes li,
 
 /* Other */
 
-input[type="text"],
+input[type="text"]:not(.metadata-property-key-input),
 input[type="search"],
 input[type="email"],
 input[type="password"],


### PR DESCRIPTION
Closes #37 

![image](https://github.com/caro401/royal-velvet/assets/12828913/a327678a-bef4-4c7d-9c82-214cf917cb08)

I've done the smallest possible fix for now, will have a proper think about how to make this theme more useful for properties soon.