### PR TITLE
Changed --code-size to 1em

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -338,7 +338,7 @@ body {
   --ribbon-background: var(--background-secondary-alt);
   --ribbon-background-collapsed: var(--background-secondary-alt);
   --code-normal: var(--purple-pink);
-  --code-size: 100%;
+  --code-size: 1em;
 
   --hr-color: var(--orange); /* Horizontal Line */
 }


### PR DESCRIPTION
Changed the `--code-size` CSS variable to be in terms of `em` instead of `%`. Instead of `100%` it is now `1em`. This is consistent with the default Obsidian usage of `--code-size`. While it may not be an issue currently visible in Obsidian with default plugins, it may one day create errors and is already creating errors in plugins.