### PR TITLE
Fix for level 7+ checkboxes

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -341,6 +341,8 @@ body {
   --code-size: 1em;
 
   --hr-color: var(--orange); /* Horizontal Line */
+
+  --checkbox-color-hover: var(--list-marker-color); /* Overrides checkbox list level 7+ hover */
 }
 
 /*Setting Dropdown*/

--- a/theme.css
+++ b/theme.css
@@ -1160,7 +1160,8 @@ ul ul ul ul ul ul ul input[type="checkbox"] {
   .has-list-bullet
   .has-list-bullet
   .has-list-bullet.contains-task-list
-  .task-list-item-checkbox:checked {
+  .task-list-item-checkbox:checked,
+  input[type="checkbox"][data-task="x"] {
   background-color: var(--list-marker-color);
   border-color: var(--list-marker-color);
 }

--- a/theme.css
+++ b/theme.css
@@ -1161,8 +1161,8 @@ ul ul ul ul ul ul ul input[type="checkbox"] {
   .has-list-bullet
   .has-list-bullet.contains-task-list
   .task-list-item-checkbox:checked {
-  background-color: var(--checkbox-color);
-  border-color: var(--checkbox-color);
+  background-color: var(--list-marker-color);
+  border-color: var(--list-marker-color);
 }
 
 /* indentation guides */


### PR DESCRIPTION
Fixes checkboxes indented to level 7 and higher having the wrong color. This change puts them in line with the bullet level 7+ color (--list-marker-color). It also removes the hover highlighting for checkboxes level 7+ to bring them in line with checkboxes level 1-6.